### PR TITLE
Added Turkish Language

### DIFF
--- a/localautosave/langs/en.js
+++ b/localautosave/langs/en.js
@@ -1,4 +1,4 @@
-tinyMCE.addI18n('en.localautosave', {
+tinyMCE.addI18n('en', {
 	'localautosave.restoreContent' : 'Restore content',
 	'localautosave.chooseVersion' : 'Choose what you want to restore',
 	'localautosave.chars' : 'chars',

--- a/localautosave/langs/es.js
+++ b/localautosave/langs/es.js
@@ -1,4 +1,4 @@
-tinyMCE.addI18n('es.localautosave', {
+tinyMCE.addI18n('es', {
 	'localautosave.restoreContent' : 'Restaurar Contenido',
 	'localautosave.chooseVersion' : 'Elije la versión que deseas restaurar',
 	'localautosave.chars' : 'caracteres',

--- a/localautosave/langs/fr_FR.js
+++ b/localautosave/langs/fr_FR.js
@@ -1,4 +1,4 @@
-tinyMCE.addI18n('fr_FR.localautosave', {
+tinyMCE.addI18n('fr_FR', {
 	'localautosave.restoreContent' : 'Restaurer le contenu',
 	'localautosave.chooseVersion' : 'Choisissez ce que vous voulez restaurer',
 	'localautosave.chars' : 'caractères',

--- a/localautosave/langs/it.js
+++ b/localautosave/langs/it.js
@@ -1,4 +1,4 @@
-tinyMCE.addI18n('it.localautosave', {
+tinyMCE.addI18n('it', {
 	'localautosave.restoreContent' : 'Ripristina il contenuto',
 	'localautosave.chooseVersion' : 'Scegli tra le versioni disponibili',
 	'localautosave.chars' : 'caratteri',

--- a/localautosave/langs/pt_BR.js
+++ b/localautosave/langs/pt_BR.js
@@ -1,4 +1,4 @@
-tinyMCE.addI18n('pt_BR.localautosave',{
+tinyMCE.addI18n('pt_BR',{
 	'localautosave.restoreContent' : 'Restaurar Conteúdo',
 	'localautosave.chooseVersion' : 'Escolha o que deseja restaurar',
 	'localautosave.chars' : 'caracteres',

--- a/localautosave/langs/tr.js
+++ b/localautosave/langs/tr.js
@@ -1,4 +1,4 @@
-tinyMCE.addI18n('tr.localautosave', {
+tinyMCE.addI18n('tr', {
     'localautosave.restoreContent' : 'İçeriği geri yükle',
     'localautosave.chooseVersion' : 'Geri yüklemek istediğiniz versiyonu seçiniz',
     'localautosave.chars' : 'karakter',

--- a/localautosave/langs/tr.js
+++ b/localautosave/langs/tr.js
@@ -1,0 +1,8 @@
+tinyMCE.addI18n('tr.localautosave', {
+    'localautosave.restoreContent' : 'İçeriği geri yükle',
+    'localautosave.chooseVersion' : 'Geri yüklemek istediğiniz versiyonu seçiniz',
+    'localautosave.chars' : 'karakter',
+    'localautosave.clearAll' :  'Kaydedilmiş tüm yedek içeriği temizle',
+    'localautosave.noContent' : 'Kaydedilmiş içerik yok.',
+    'localautosave.ifRestore' : 'Bu içeriği geri yüklemeniz durumunda, şu anki içerik geri döndürülemeyecek şekilde kaybolacaktır.\n\nBu içeriği geri yüklemek istediğinize emin misiniz?'
+});


### PR DESCRIPTION
i've added Turkish language, but also i think removing the plugin names as suffixes from translation function call is a better solution, as all the labels are notated with the plugin name's prefix. Hence i haven't tried the previous versions but in TinyMCE v4.1.9, translations are not working with that suffixes in the function call.