### PR TITLE
Added Bower 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
   "authors": [
     "Felipe Valtl de Mello <https://github.com/valtlfelipe>"
   ],
+  "main": "localautosave",
   "keywords": ["tinymce", "local storage"],
   "license": "MIT",
   "ignore": [

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "tinymce-localautosave",
+  "version": "0.4.2",
+  "homepage": "https://github.com/valtlfelipe/TinyMCE-LocalAutoSave",
+  "authors": [
+    "Felipe Valtl de Mello <https://github.com/valtlfelipe>"
+  ],
+  "keywords": ["tinymce", "local storage"],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "description": "Save the TinyMCE (v4.x) content to LocalStorage* or SessionStorage* in your Browser to avoid losing your content in an page refresh",
+  "dependencies": {
+    "tinymce": "4.*"
+  }
+}


### PR DESCRIPTION
Added `bower.json` file and registered the plugin to bower repository. 

One can simply install the package with `bower install tinymce-localautosave` now.

After merging, it would be great if you can release the new version as I've set the version as `0.4.2` within the bower file.